### PR TITLE
remove primIndices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(bvh INTERFACE)
 target_compile_features(bvh INTERFACE cxx_std_17)
 target_compile_options(bvh INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -march=native>
 )
 target_include_directories(bvh INTERFACE "include")
 

--- a/example/path-tracing/main.cpp
+++ b/example/path-tracing/main.cpp
@@ -1,6 +1,7 @@
 #define TINYOBJLOADER_IMPLEMENTATION
 #include <omp.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -152,6 +153,7 @@ int main() {
   Image img(width, height);
   Camera camera(camPos, camForward);
 
+  const auto startTime = std::chrono::system_clock::now();
 #pragma omp parallel for schedule(dynamic, 1)
   for (int j = 0; j < height; ++j) {
     for (int i = 0; i < width; ++i) {
@@ -169,6 +171,11 @@ int main() {
       img.setPixel(i, j, color);
     }
   }
+  std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::system_clock::now() - startTime)
+                   .count()
+            << "ms" << std::endl;
+
   img.writePPM("output.ppm");
 
   return 0;

--- a/example/simple-example/main.cpp
+++ b/example/simple-example/main.cpp
@@ -1,4 +1,5 @@
 #define TINYOBJLOADER_IMPLEMENTATION
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -69,6 +70,7 @@ int main() {
 
   Ray ray(Vec3(0, 0, -10), Vec3(0, 0, 1));
   IntersectInfo info;
+  const auto startTime = std::chrono::system_clock::now();
   if (bvh.intersect(ray, info)) {
     std::cout << "t: " << info.t << std::endl;
     std::cout << "hitPos: " << info.hitPos << std::endl;
@@ -77,6 +79,10 @@ int main() {
     std::cout << "barycentric: " << info.barycentric[0] << ", "
               << info.barycentric[1] << std::endl;
   }
+  std::cout << std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::system_clock::now() - startTime)
+                   .count()
+            << "μs" << std::endl;
 
   return 0;
 }

--- a/example/simple-rendering/main.cpp
+++ b/example/simple-rendering/main.cpp
@@ -1,4 +1,5 @@
 #define TINYOBJLOADER_IMPLEMENTATION
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -74,6 +75,8 @@ int main() {
 
   Image img(width, height);
   Camera camera(camPos, camForward);
+
+  const auto startTime = std::chrono::system_clock::now();
   for (int j = 0; j < height; ++j) {
     for (int i = 0; i < width; ++i) {
       const float u = (2.0f * i - width) / height;
@@ -88,6 +91,11 @@ int main() {
       }
     }
   }
+  std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::system_clock::now() - startTime)
+                   .count()
+            << "ms" << std::endl;
+
   img.writePPM("output.ppm");
 
   return 0;

--- a/include/core/triangle.hpp
+++ b/include/core/triangle.hpp
@@ -7,7 +7,7 @@
 class Triangle {
  private:
   const Polygon* polygon;
-  const unsigned int faceID;
+  unsigned int faceID;
 
  public:
   Triangle(const Polygon* polygon, unsigned int faceID)


### PR DESCRIPTION
PrimIndicesを消したことで葉ノードのデータアクセスが最適化された。
`example/simple-rendering`において

OptimizedBVH
PrimIndicesあり: 3679ms
PrimIndicesなし: 3411ms

Simple BVH
PrimIndicesあり: 3839ms
PrimIndicesなし: 3506ms